### PR TITLE
Changed code execution shortcut from Enter to Shift + Enter

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,7 +16,7 @@ export default {
   },
   data() {
     return {
-      simple: `console.log("Привет, мир!");\nconst x = 10;\nconst y = 20;\nconsole.log(x + y);`, // Пример кода
+      simple: `// Press Shift+Enter to execute code.\n// Press Enter to go to next line.\nconsole.log("Привет, мир!");\nconst x = 10;\nconst y = 20;\nconsole.log(x + y);`, // Пример кода
       output: null, // Переменная для хранения результата выполнения
       globalScope : {},
       executionTime: {},
@@ -91,7 +91,7 @@ export default {
     },
     handleKeyDown(event) {
       // Проверяем, была ли нажата клавиша Enter и не нажата клавиша Shift
-      if (event.key === 'Enter' && !event.shiftKey) {
+      if (event.key === 'Enter' && event.shiftKey) {
         // Отменяем стандартное поведение (создание новой строки)
         event.preventDefault();
 


### PR DESCRIPTION
The project uses Enter to execute code and `Shift + Enter` to go to a new line.
This causes troubles for someone not familiar with the project as the shortcuts have not been mentioned anywhere in the projects.
I swapped the command of shortcuts `Enter` and `Shift + Enter` because people are more familiar with pressing Enter to go to the next line.
`Shift + Enter` seems the perfect shortcut to quickly execute code which the project aims to achieve.